### PR TITLE
Fix blender26-meshio MQO exporter for Blender 2.72b

### DIFF
--- a/blender26-meshio/export_mqo.py
+++ b/blender26-meshio/export_mqo.py
@@ -217,7 +217,7 @@ class MqoExporter(object):
 
         # depth
         io.write("\tdepth %d\r\n" % info.depth)
-
+        io.write("\tvisible %d\r\n" % 15)
         # mirror
         if not self.apply_modifier:
             if bl.modifier.hasType(obj, 'MIRROR'):
@@ -267,8 +267,8 @@ class MqoExporter(object):
         io.write("\t}\r\n")
 
         # faces
-        io.write("\tface %d {\r\n" % len(mesh.faces))
-        for i, face in enumerate(mesh.faces):
+        io.write("\tface %d {\r\n" % len(mesh.polygons))
+        for i, face in enumerate(mesh.polygons):
             count=bl.face.getVertexCount(face)
             # V
             io.write("\t\t%d V(" % count)


### PR DESCRIPTION
The blender26-meshio MQO exporter fails in Blender version 2.72b because
mesh.faces was removed from the API and replaced with mesh.polygons
about, I think, Blender 2.63.

MQO exporter now writes the "visible" property for objects in the MQO.

The absence of this property is no problem for Metasequoia but is needed
for my home made MQO readers.
