### PR TITLE
 export to shape key 'type 0' (bug fix) #23 

### DIFF
--- a/blender26-meshio/export_pmd.py
+++ b/blender26-meshio/export_pmd.py
@@ -213,7 +213,7 @@ def write(ex, path):
     for i, m in enumerate(ex.oneSkinMesh.morphList):
         v=englishmap.getUnicodeSkinName(m.name)
         if not v:
-            v=[m.name, m.name, 0]
+            v=[m.name, m.name, 4]
         assert(v)
         # morph
         morph=pmd.Morph(v[1].encode("cp932"))

--- a/blender26-meshio/export_pmx.py
+++ b/blender26-meshio/export_pmx.py
@@ -295,7 +295,7 @@ def create_pmx(ex, enable_bdef4=True):
     for i, m in enumerate(ex.oneSkinMesh.morphList[1:]):
         # name
         english_name="morph: %d" % i
-        panel=0
+        panel=4
         for en, n, p in englishmap.skinMap:
             if n==m.name:
                 english_name=en


### PR DESCRIPTION
 export to shape key 'type 0' (bug fix) #23 
 
 If you create a shape key/morph/facial for your model in Blender, it will not export correctly with Pymeshio. The shape key type of the exported shape key will be 0. There is no facial type 0 for a pmd or pmx model. The allowed types are 1,2,3,4 (brow, eyes, mouth, other). 
 
  グーグルtanslate：
 キー「タイプ0」（バグ修正）＃23を成形する輸出
 
 シェイプキーを作成した場合/ Blenderのモデルのためのフェイシャル/モーフ、それはPymeshioに正しくエクスポートされません。エクスポートされた形状のキーの形状キータイプは、PMDやPMXモデルには顔のタイプ0はありませんが0になります。承認されたタイプは、1,2,3,4（眉、目、口、その他）です。