### PR TITLE
Bdef struct doesn't have type attribution and fix it by using type()

### DIFF
--- a/pymeshio/pmx/writer.py
+++ b/pymeshio/pmx/writer.py
@@ -71,7 +71,7 @@ class Writer(common.BinaryWriter):
             self.write_float(deform.weight3)
         else:
             raise common.WriteException(
-                    "unknown deform type: {0}".format(deform.type))
+                    "unknown deform type: {0}".format(type(deform)))
 
     def write_indices(self, indices):
         self.write_int(len(indices), 4)


### PR DESCRIPTION
Bdef and other similar classes don't have type member, but pymeshio accessed Bdef.type and raised AttributeError.
I fixed Bdef.type -> type(Bdef)